### PR TITLE
usr/sbin/checkbox-run-plan: apt-get upgrade only when internet is ava…

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,13 @@
-prepare-checkbox-sanity (1.0.5ubuntu1) UNRELEASED; urgency=medium
+prepare-checkbox-sanity (1.0.6) UNRELEASED; urgency=medium
 
+  [ Alex Tu ]
   * autodpkgtest
 
- -- Alex Tu <alex.tu@canonical.com>  Thu, 14 May 2020 21:59:46 +0800
+  [ Yuan-Chen Cheng ]
+  * usr/sbin/checkbox-run-plan: apt-get upgrade only when internet is
+    available.
+
+ -- Yuan-Chen Cheng <yc.cheng@canonical.com>  Wed, 09 Sep 2020 18:36:11 +0800
 
 prepare-checkbox-sanity (1.0.5) bionic; urgency=medium
 

--- a/usr/sbin/checkbox-run-plan
+++ b/usr/sbin/checkbox-run-plan
@@ -101,9 +101,14 @@ if [ -n "$CHECKBOX_CONF" ] && [ -z "${CHECKBOX_CONF##http*}" ]; then
     fi
 fi
 
-# always use the latest plan
+# always use the latest plan if ineternet access is available.
 if [ -z "${PLAN##pc*}" ]; then
-    sudo apt-get update; sudo apt-get install -y plainbox-provider-pc-sanity || true
+    for r in 1 2 3; do
+        if ping -c 2 8.8.8.8; then
+            sudo apt-get update; sudo apt-get install -y plainbox-provider-pc-sanity
+            break
+        fi
+    done
 fi
 
 # prepare needed user environment


### PR DESCRIPTION
usr/sbin/checkbox-run-plan: apt-get upgrade only when internet is available.

test pass on my side.